### PR TITLE
Feature/env 8base

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ See [Vite Configuration Reference](https://vitejs.dev/config/).
 
 ## Project Setup
 
+
+
 ```sh
 npm install
+```
+
+## API configuration
+
+```sh
+echo VITE_API_ENDPOINT=\"YOUR_API_URL\" >> .env
 ```
 
 ### Compile and Hot-Reload for Development

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import router from "./router";
 import "@/assets/base.css";
 import "@progress/kendo-theme-default/dist/all.css";
 
+const apiEndponit = import.meta.env.VITE_API_ENDPOINT
+
 import {
   ApolloClient,
   createHttpLink,
@@ -17,7 +19,7 @@ import { DefaultApolloClient } from "@vue/apollo-composable";
 // HTTP connection to the API
 const httpLink = createHttpLink({
   // You should use an absolute URL here
-  uri: "https://uk.api.8base.com/cl5hs0p9f08p309l5c70w358g",
+  uri: apiEndponit,
 });
 
 // Cache implementation


### PR DESCRIPTION
I used an environment variable to import the 8base API URL. From now on, anyone needs to create a .env file with the content VITE_API_ENDPOINT="YOUR_API_URL". I also updated the README with the shell command to do it from the terminal.